### PR TITLE
#83061: Avoid usage of deprecated constructors (new Integer(...))

### DIFF
--- a/src/main/java/com/intershop/beehive/isml/internal/parser/ISMLTagCompiler.java
+++ b/src/main/java/com/intershop/beehive/isml/internal/parser/ISMLTagCompiler.java
@@ -1189,7 +1189,7 @@ public class ISMLTagCompiler implements ISMLtoJSPcompilerConstants
                     // process style attribute (optional - value necessary)
                     if (hasValueAttribute(attributes, ATT_STYLE))
                     {
-                        format = "new Integer(" + getValueAttribute(attributes, ATT_STYLE) + ')';
+                        format = "Integer.valueOf(" + getValueAttribute(attributes, ATT_STYLE) + ')';
                     }
                     else if (hasExpressionAttribute(attributes, ATT_STYLE))
                     {


### PR DESCRIPTION
Replace "new Integer(...)" with "Integer.valueOf(...)" to avoid warnings about deprecated code 